### PR TITLE
Add flush on file open and busy timeout

### DIFF
--- a/rmf_scheduler_ros2/src/SqliteDataSource.cpp
+++ b/rmf_scheduler_ros2/src/SqliteDataSource.cpp
@@ -102,6 +102,8 @@ void SqliteDataSource::_Transaction::_finish()
 SqliteDataSource::SqliteDataSource(const std::string& file)
 {
   sqlite3_open(file.c_str(), &this->_db);
+  sqlite3_busy_timeout(this->_db, kDatabaseBusyTimeoutMs);
+  sqlite3_db_cacheflush(this->_db);
   char* errmsg;
 
   int result = sqlite3_exec(

--- a/rmf_scheduler_ros2/src/SqliteDataSource.hpp
+++ b/rmf_scheduler_ros2/src/SqliteDataSource.hpp
@@ -66,6 +66,8 @@ private:
     void _finish();
   };
 
+  static constexpr int64_t kDatabaseBusyTimeoutMs = 1000;
+
 public:
   SqliteDataSource(const std::string& file);
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

It has been observed in deployments that sometimes the database is locked at startup and currently any operation fails if that is the case, i.e.:

```
[rmf_scheduler_ros2-5] [ERROR] [1656404894.244706048] [rmf_scheduler]: database is locked
[rmf_scheduler_ros2-5] [ERROR] [1656404894.310371938] [Scheduler]: Failed to run trigger 'req_0': database is locked
[rmf_scheduler_ros2-5] [ERROR] [1656404894.330058529] [Scheduler]: Failed to run trigger 'req_4': database is locked
[rmf_scheduler_ros2-5] [ERROR] [1656404894.349656721] [Scheduler]: Failed to run trigger 'req_past': database is locked
```

This condition has only been observed on fresh start after a sudden crash of the node.

### Fix applied

This PR adds a busy timeout of one second to the database operations in case it happens to be locked when a write operation is invoked, as well as a flush operation to be called as soon as the file is opened to clear any operation that might have been saved to the journal but not fully committed because of abrupt terminations